### PR TITLE
5 Perfil De Usuario

### DIFF
--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -4,13 +4,58 @@ import 'package:biodetect/views/session/inicio_sesion.dart';
 import 'package:flutter/material.dart';
 import 'package:biodetect/themes.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-class ProfileScreen extends StatelessWidget {
+class ProfileScreen extends StatefulWidget {
   const ProfileScreen({super.key});
 
+  @override
+  State<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends State<ProfileScreen> {
+  late Future<Map<String, dynamic>> _userDataFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _userDataFuture = _loadUserData();
+  }
+
+  Future<Map<String, dynamic>> _loadUserData() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) throw Exception('No hay usuario autenticado');
+
+    // Obtener datos del usuario
+    final userDoc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
+    final userData = userDoc.data() ?? {};
+
+    // Obtener estadísticas de actividad
+    final activityDoc = await FirebaseFirestore.instance.collection('user_activity').doc(user.uid).get();
+    final activityData = activityDoc.data() ?? {};
+
+    // Obtener insignias (detalles)
+    List<Map<String, dynamic>> badgesData = [];
+    if (userData['badges'] != null && userData['badges'] is List) {
+      final badgeIds = List<String>.from(userData['badges']);
+      if (badgeIds.isNotEmpty) {
+        final badgesSnap = await FirebaseFirestore.instance
+            .collection('badges')
+            .where(FieldPath.documentId, whereIn: badgeIds)
+            .get();
+        badgesData = badgesSnap.docs.map((doc) => doc.data()).toList();
+      }
+    }
+
+    return {
+      'user': userData,
+      'activity': activityData,
+      'badges': badgesData,
+    };
+  }
+
   Future<void> _cerrarSesion(BuildContext context) async {
-    // Mostrar diálogo de confirmación
     final bool? confirmar = await showDialog<bool>(
       context: context,
       builder: (BuildContext context) {
@@ -44,10 +89,8 @@ class ProfileScreen extends StatelessWidget {
       },
     );
 
-    // Si el usuario confirmó, cerrar sesión
     if (confirmar == true && context.mounted) {
       try {
-        // Mostrar indicador de carga
         showDialog(
           context: context,
           barrierDismissible: false,
@@ -55,35 +98,18 @@ class ProfileScreen extends StatelessWidget {
             child: CircularProgressIndicator(color: AppColors.mintGreen),
           ),
         );
-
-        // Limpiar preferencias de "recordar sesión" - NUEVO
         final prefs = await SharedPreferences.getInstance();
         await prefs.setBool('auto_login', false);
-        // Mantener email guardado si el usuario lo tenía marcado anteriormente
-        // await prefs.remove('saved_email'); // Opcional: descomentar para limpiar email también
-
-        // Cerrar sesión en Firebase
         await FirebaseAuth.instance.signOut();
-
-        // Cerrar diálogo de carga
-        if (context.mounted) {
-          Navigator.of(context).pop();
-        }
-
-        // Navegar a la pantalla de inicio de sesión
+        if (context.mounted) Navigator.of(context).pop();
         if (context.mounted) {
           Navigator.of(context).pushAndRemoveUntil(
             MaterialPageRoute(builder: (context) => const InicioSesion()),
-            (route) => false, // Elimina todas las pantallas anteriores
+            (route) => false,
           );
         }
       } catch (e) {
-        // Cerrar diálogo de carga si está abierto
-        if (context.mounted) {
-          Navigator.of(context).pop();
-        }
-
-        // Mostrar error
+        if (context.mounted) Navigator.of(context).pop();
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
@@ -98,14 +124,6 @@ class ProfileScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Valores por defecto o mensaje si no hay datos
-    final String nombre = "Nombre no disponible";
-    final String correo = "Correo no disponible";
-    final bool verificado = false;
-    final int identificaciones = 0;
-    final int bitacoras = 0;
-    final int insignias = 0;
-
     return Scaffold(
       appBar: AppBar(
         title: const Text(
@@ -115,137 +133,202 @@ class ProfileScreen extends StatelessWidget {
         backgroundColor: AppColors.backgroundNavBarsLigth,
         iconTheme: const IconThemeData(color: AppColors.textWhite),
         elevation: 0,
-        centerTitle: false, // Título alineado a la izquierda
+        centerTitle: false,
       ),
       body: Container(
         decoration: const BoxDecoration(
           gradient: AppColors.backgroundLightGradient,
         ),
-        child: ListView(
-          padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 0),
-          children: [
-            const SizedBox(height: 32),
-            // Sección 1: Header
-            Column(
-              mainAxisAlignment: MainAxisAlignment.center,
+        child: FutureBuilder<Map<String, dynamic>>(
+          future: _userDataFuture,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator(color: AppColors.mintGreen));
+            }
+            if (snapshot.hasError) {
+              return Center(
+                child: Text(
+                  'Error al cargar perfil: ${snapshot.error}',
+                  style: const TextStyle(color: AppColors.warning),
+                ),
+              );
+            }
+
+            final user = snapshot.data!['user'] ?? {};
+            final activity = snapshot.data!['activity'] ?? {};
+            final badges = snapshot.data!['badges'] ?? [];
+
+            final String nombre = user['fullname'] ?? 'Nombre no disponible';
+            final String correo = user['email'] ?? 'Correo no disponible';
+            final String? foto = user['profilePicture'];
+            final bool verificado = FirebaseAuth.instance.currentUser?.emailVerified ?? false;
+            final int identificaciones = activity['speciesIdentified']?['total'] ?? 0;
+            final int bitacoras = activity['fieldNotesCreated'] ?? 0;
+            final int insignias = (user['badges'] as List?)?.length ?? 0;
+
+            return ListView(
+              padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 0),
               children: [
-                // Foto de perfil
-                Card(
-                  shape: const CircleBorder(),
-                  color: Colors.transparent,
-                  elevation: 4,
-                  child: CircleAvatar(
-                    radius: 75,
-                    backgroundColor: AppColors.forestGreen,
-                    child: CircleAvatar(
-                      radius: 72,
-                      backgroundImage: const AssetImage('assets/ic_default_profile.png'),
-                      backgroundColor: AppColors.white,
-                    ),
-                  ),
-                ),
-                const SizedBox(height: 16),
-                // Nombre
-                Text(
-                  nombre.isNotEmpty ? nombre : "Nombre no disponible",
-                  style: const TextStyle(
-                    color: AppColors.textWhite,
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                // Correo + verificación
-                Row(
+                const SizedBox(height: 32),
+                // Sección 1: Header
+                Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Text(
-                      correo.isNotEmpty ? correo : "Correo no disponible",
-                      style: const TextStyle(
-                        color: AppColors.textWhite,
-                        fontSize: 14,
+                    // Foto de perfil
+                    Card(
+                      shape: const CircleBorder(),
+                      color: Colors.transparent,
+                      elevation: 4,
+                      child: CircleAvatar(
+                        radius: 75,
+                        backgroundColor: AppColors.forestGreen,
+                        backgroundImage: (foto != null && foto.isNotEmpty)
+                            ? NetworkImage(foto)
+                            : const AssetImage('assets/ic_default_profile.png') as ImageProvider,
+                        child: foto == null || foto.isEmpty
+                            ? const Icon(Icons.person, size: 72, color: AppColors.slateGrey)
+                            : null,
                       ),
                     ),
-                    if (verificado)
-                      const Padding(
-                        padding: EdgeInsets.only(left: 8),
-                        child: Icon(Icons.verified, color: AppColors.aquaBlue, size: 20),
+                    const SizedBox(height: 16),
+                    // Nombre
+                    Text(
+                      nombre,
+                      style: const TextStyle(
+                        color: AppColors.textWhite,
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
                       ),
+                    ),
+                    // Correo + verificación
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          correo,
+                          style: const TextStyle(
+                            color: AppColors.textWhite,
+                            fontSize: 14,
+                          ),
+                        ),
+                        if (verificado)
+                          const Padding(
+                            padding: EdgeInsets.only(left: 8),
+                            child: Icon(Icons.verified, color: AppColors.aquaBlue, size: 20),
+                          ),
+                      ],
+                    ),
                   ],
                 ),
-              ],
-            ),
-            const SizedBox(height: 32),
-            // Sección 2: Estadísticas
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Row(
-                children: [
-                  _EstadisticaCard(
-                    icon: Icons.bug_report,
-                    label: "Identificaciones",
-                    value: identificaciones,
-                    iconColor: AppColors.textBlueNormal,
-                  ),
-                  _EstadisticaCard(
-                    icon: Icons.menu_book,
-                    label: "Bitácoras",
-                    value: bitacoras,
-                    iconColor: AppColors.textBlueNormal,
-                  ),
-                  _EstadisticaCard(
-                    icon: Icons.emoji_events,
-                    label: "Insignias",
-                    value: insignias,
-                    iconColor: AppColors.textBlueNormal,
-                  ),
-                ],
-              ),
-            ),
-            const SizedBox(height: 32),
-            // Sección 3: Acciones
-            Column(
-              children: [
-                _AccionPerfilTile(
-                  icon: Icons.menu_book,
-                  iconColor: AppColors.textBlueNormal,
-                  label: "Mis Bitácoras",
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => const MisBitacorasScreen(),
+                const SizedBox(height: 32),
+                // Sección 2: Estadísticas
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Row(
+                    children: [
+                      _EstadisticaCard(
+                        icon: Icons.bug_report,
+                        label: "Identificaciones",
+                        value: identificaciones,
+                        iconColor: AppColors.textBlueNormal,
                       ),
-                    );
-                  },
-                  trailing: Icons.arrow_forward_ios,
-                ),
-                _DividerPerfil(),
-                _AccionPerfilTile(
-                  icon: Icons.settings,
-                  iconColor: AppColors.textBlueNormal,
-                  label: "Editar Perfil",
-                  onTap: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => const EditarPerfil(),
+                      _EstadisticaCard(
+                        icon: Icons.menu_book,
+                        label: "Bitácoras",
+                        value: bitacoras,
+                        iconColor: AppColors.textBlueNormal,
                       ),
-                    );
-                  },
-                  trailing: Icons.arrow_forward_ios,
+                      _EstadisticaCard(
+                        icon: Icons.emoji_events,
+                        label: "Insignias",
+                        value: insignias,
+                        iconColor: AppColors.textBlueNormal,
+                      ),
+                    ],
+                  ),
                 ),
-                _DividerPerfil(),
-                _AccionPerfilTile(
-                  icon: Icons.logout,
-                  iconColor: AppColors.warning, // Cambiar color a warning
-                  label: "Cerrar Sesión",
-                  onTap: () => _cerrarSesion(context), // Llamar a la función
-                  trailing: null,
+                const SizedBox(height: 32),
+                // Sección 2.1: Insignias (opcional, muestra iconos)
+                if (badges.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: SizedBox(
+                      height: 60,
+                      child: ListView.separated(
+                        scrollDirection: Axis.horizontal,
+                        itemCount: badges.length,
+                        separatorBuilder: (_, __) => const SizedBox(width: 12),
+                        itemBuilder: (context, i) {
+                          final badge = badges[i];
+                          return Tooltip(
+                            message: badge['name'] ?? '',
+                            child: CircleAvatar(
+                              backgroundColor: AppColors.slateGreen,
+                              radius: 28,
+                              backgroundImage: badge['iconUrl'] != null
+                                  ? NetworkImage(badge['iconUrl'])
+                                  : null,
+                              child: badge['iconUrl'] == null
+                                  ? const Icon(Icons.emoji_events, color: AppColors.textWhite)
+                                  : null,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                if (badges.isNotEmpty) const SizedBox(height: 32),
+                // Sección 3: Acciones
+                Column(
+                  children: [
+                    _AccionPerfilTile(
+                      icon: Icons.menu_book,
+                      iconColor: AppColors.textBlueNormal,
+                      label: "Mis Bitácoras",
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const MisBitacorasScreen(),
+                          ),
+                        );
+                      },
+                      trailing: Icons.arrow_forward_ios,
+                    ),
+                    _DividerPerfil(),
+                    _AccionPerfilTile(
+                      icon: Icons.settings,
+                      iconColor: AppColors.textBlueNormal,
+                      label: "Editar Perfil",
+                      onTap: () async {
+                        final result = await Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const EditarPerfil(),
+                          ),
+                        );
+                        if (result == true) {
+                          setState(() {
+                            _userDataFuture = _loadUserData();
+                          });
+                        }
+                      },
+                      trailing: Icons.arrow_forward_ios,
+                    ),
+                    _DividerPerfil(),
+                    _AccionPerfilTile(
+                      icon: Icons.logout,
+                      iconColor: AppColors.warning,
+                      label: "Cerrar Sesión",
+                      onTap: () => _cerrarSesion(context),
+                      trailing: null,
+                    ),
+                  ],
                 ),
+                const SizedBox(height: 32),
               ],
-            ),
-            const SizedBox(height: 32),
-          ],
+            );
+          },
         ),
       ),
     );

--- a/lib/views/user/cambiar_contrasena.dart
+++ b/lib/views/user/cambiar_contrasena.dart
@@ -1,4 +1,5 @@
 import 'package:biodetect/themes.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
 class CambiarContrasenaScreen extends StatefulWidget {
@@ -18,6 +19,11 @@ class _CambiarContrasenaScreenState extends State<CambiarContrasenaScreen> {
   String? _error;
   int _passwordStrength = 0;
 
+  // Ojos para mostrar/ocultar contraseñas
+  bool _showCurrent = false;
+  bool _showNew = false;
+  bool _showConfirm = false;
+
   void _checkPasswordStrength(String value) {
     int strength = 0;
     if (value.length >= 8) strength++;
@@ -30,18 +36,66 @@ class _CambiarContrasenaScreenState extends State<CambiarContrasenaScreen> {
     });
   }
 
-  void _onGuardar() {
+  Future<void> _onGuardar() async {
+    if (!_formKey.currentState!.validate()) return;
     setState(() {
       _loading = true;
       _error = null;
     });
-    // Simulación de proceso
-    Future.delayed(const Duration(seconds: 2), () {
+
+    final user = FirebaseAuth.instance.currentUser;
+    final currentPassword = _currentController.text.trim();
+    final newPassword = _newController.text.trim();
+    final confirmPassword = _confirmController.text.trim();
+
+    if (newPassword != confirmPassword) {
       setState(() {
         _loading = false;
-        // Aquí iría la lógica real de cambio de contraseña
+        _error = 'Las contraseñas nuevas no coinciden.';
       });
-    });
+      return;
+    }
+
+    try {
+      // Reautenticación
+      final cred = EmailAuthProvider.credential(
+        email: user!.email!,
+        password: currentPassword,
+      );
+      await user.reauthenticateWithCredential(cred);
+
+      // Cambiar contraseña
+      await user.updatePassword(newPassword);
+
+      setState(() {
+        _loading = false;
+      });
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Contraseña actualizada correctamente')),
+        );
+        Navigator.pop(context);
+      }
+    } on FirebaseAuthException catch (e) {
+      setState(() {
+        _loading = false;
+        if (e.code == 'wrong-password') {
+          _error = 'La contraseña actual es incorrecta.';
+        } else if (e.code == 'weak-password') {
+          _error = 'La nueva contraseña es demasiado débil.';
+        } else if (e.code == 'requires-recent-login') {
+          _error = 'Por seguridad, vuelve a iniciar sesión e inténtalo de nuevo.';
+        } else {
+          _error = 'Error: ${e.message}';
+        }
+      });
+    } catch (e) {
+      setState(() {
+        _loading = false;
+        _error = 'Error inesperado: $e';
+      });
+    }
   }
 
   @override
@@ -59,165 +113,201 @@ class _CambiarContrasenaScreenState extends State<CambiarContrasenaScreen> {
         decoration: const BoxDecoration(
           gradient: AppColors.backgroundLightGradient,
         ),
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
         child: Stack(
           children: [
             Center(
               child: SingleChildScrollView(
-                child: Card(
-                  color: AppColors.backgroundCard,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  elevation: 8,
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Form(
-                      key: _formKey,
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          // Título
-                          const Text(
-                            'Cambiar Contraseña',
-                            style: TextStyle(
-                              color: AppColors.textWhite,
-                              fontSize: 24,
-                              fontWeight: FontWeight.bold,
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      // Título
+                      const Text(
+                        'Cambiar Contraseña',
+                        style: TextStyle(
+                          color: AppColors.textBlack,
+                          fontSize: 28,
+                          fontWeight: FontWeight.bold,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 32),
+                      // Campo: Contraseña actual
+                      TextFormField(
+                        controller: _currentController,
+                        obscureText: !_showCurrent,
+                        decoration: InputDecoration(
+                          hintText: 'Contraseña actual',
+                          filled: true,
+                          fillColor: AppColors.paleGreen,
+                          hintStyle: const TextStyle(color: AppColors.textBlack),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                            borderSide: BorderSide.none,
+                          ),
+                          contentPadding: const EdgeInsets.symmetric(vertical: 20, horizontal: 18),
+                          suffixIcon: IconButton(
+                            icon: Icon(
+                              _showCurrent ? Icons.visibility : Icons.visibility_off,
+                              color: AppColors.slateGrey,
+                            ),
+                            onPressed: () {
+                              setState(() {
+                                _showCurrent = !_showCurrent;
+                              });
+                            },
+                          ),
+                        ),
+                        style: const TextStyle(color: AppColors.textBlack),
+                      ),
+                      const SizedBox(height: 20),
+                      // Campo: Nueva contraseña
+                      TextFormField(
+                        controller: _newController,
+                        obscureText: !_showNew,
+                        onChanged: _checkPasswordStrength,
+                        decoration: InputDecoration(
+                          hintText: 'Nueva contraseña',
+                          filled: true,
+                          fillColor: AppColors.paleGreen,
+                          hintStyle: const TextStyle(color: AppColors.textBlack),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                            borderSide: BorderSide.none,
+                          ),
+                          contentPadding: const EdgeInsets.symmetric(vertical: 20, horizontal: 18),
+                          suffixIcon: IconButton(
+                            icon: Icon(
+                              _showNew ? Icons.visibility : Icons.visibility_off,
+                              color: AppColors.slateGrey,
+                            ),
+                            onPressed: () {
+                              setState(() {
+                                _showNew = !_showNew;
+                              });
+                            },
+                          ),
+                        ),
+                        style: const TextStyle(color: AppColors.textBlack),
+                      ),
+                      // Barra de fortaleza de contraseña
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        child: Row(
+                          children: List.generate(5, (i) {
+                            return Expanded(
+                              child: Container(
+                                height: 4,
+                                margin: EdgeInsets.symmetric(horizontal: i == 1 || i == 3 ? 2 : 0),
+                                decoration: BoxDecoration(
+                                  color: i < _passwordStrength
+                                      ? AppColors.mintGreen
+                                      : AppColors.slateGrey,
+                                  borderRadius: BorderRadius.circular(2),
+                                ),
+                              ),
+                            );
+                          }),
+                        ),
+                      ),
+                      // Campo: Confirmar nueva contraseña
+                      TextFormField(
+                        controller: _confirmController,
+                        obscureText: !_showConfirm,
+                        decoration: InputDecoration(
+                          hintText: 'Confirmar nueva contraseña',
+                          filled: true,
+                          fillColor: AppColors.paleGreen,
+                          hintStyle: const TextStyle(color: AppColors.textBlack),
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(12),
+                            borderSide: BorderSide.none,
+                          ),
+                          contentPadding: const EdgeInsets.symmetric(vertical: 20, horizontal: 18),
+                          suffixIcon: IconButton(
+                            icon: Icon(
+                              _showConfirm ? Icons.visibility : Icons.visibility_off,
+                              color: AppColors.slateGrey,
+                            ),
+                            onPressed: () {
+                              setState(() {
+                                _showConfirm = !_showConfirm;
+                              });
+                            },
+                          ),
+                        ),
+                        style: const TextStyle(color: AppColors.textBlack),
+                      ),
+                      const SizedBox(height: 28),
+                      // Mensaje de error
+                      if (_error != null)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 12),
+                          child: Text(
+                            _error!,
+                            style: const TextStyle(
+                              color: AppColors.warning,
+                              fontSize: 13,
                             ),
                             textAlign: TextAlign.center,
                           ),
-                          const SizedBox(height: 24),
-                          // Campo: Contraseña actual
-                          TextFormField(
-                            controller: _currentController,
-                            obscureText: true,
-                            decoration: InputDecoration(
-                              hintText: 'Contraseña actual',
-                              filled: true,
-                              fillColor: AppColors.paleGreen,
-                              hintStyle: const TextStyle(color: AppColors.textBlack),
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(8),
-                                borderSide: BorderSide.none,
-                              ),
-                            ),
-                            style: const TextStyle(color: AppColors.textWhite),
-                          ),
-                          const SizedBox(height: 16),
-                          // Campo: Nueva contraseña
-                          TextFormField(
-                            controller: _newController,
-                            obscureText: true,
-                            onChanged: _checkPasswordStrength,
-                            decoration: InputDecoration(
-                              hintText: 'Nueva contraseña',
-                              filled: true,
-                              fillColor: AppColors.paleGreen,
-                              hintStyle: const TextStyle(color: AppColors.textBlack),
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(8),
-                                borderSide: BorderSide.none,
-                              ),
-                            ),
-                            style: const TextStyle(color: AppColors.textWhite),
-                          ),
-                          // Barra de fortaleza de contraseña
-                          Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 12),
-                            child: Row(
-                              children: List.generate(5, (i) {
-                                return Expanded(
-                                  child: Container(
-                                    height: 4,
-                                    margin: EdgeInsets.symmetric(horizontal: i == 1 || i == 3 ? 2 : 0),
-                                    decoration: BoxDecoration(
-                                      color: i < _passwordStrength
-                                          ? AppColors.mintGreen
-                                          : AppColors.slateGrey,
-                                      borderRadius: BorderRadius.circular(2),
-                                    ),
-                                  ),
-                                );
-                              }),
-                            ),
-                          ),
-                          // Campo: Confirmar nueva contraseña
-                          TextFormField(
-                            controller: _confirmController,
-                            obscureText: true,
-                            decoration: InputDecoration(
-                              hintText: 'Confirmar nueva contraseña',
-                              filled: true,
-                              fillColor: AppColors.paleGreen,
-                              hintStyle: const TextStyle(color: AppColors.textBlack),
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(8),
-                                borderSide: BorderSide.none,
-                              ),
-                            ),
-                            style: const TextStyle(color: AppColors.textWhite),
-                          ),
-                          const SizedBox(height: 24),
-                          // Mensaje de error
-                          if (_error != null)
-                            Padding(
-                              padding: const EdgeInsets.only(bottom: 12),
-                              child: Text(
-                                _error!,
-                                style: const TextStyle(
-                                  color: AppColors.warning,
-                                  fontSize: 12,
+                        ),
+                      // Botones de acción
+                      Row(
+                        children: [
+                          Expanded(
+                            child: ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: AppColors.buttonBrown2,
+                                foregroundColor: AppColors.textBlack,
+                                minimumSize: const Size(0, 50),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(12),
                                 ),
+                                elevation: 2,
+                              ),
+                              onPressed: _loading
+                                  ? null
+                                  : () {
+                                Navigator.pop(context);
+                              },
+                              child: const Text(
+                                'Cancelar',
+                                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
                               ),
                             ),
-                          // Botones de acción
-                          Row(
-                            children: [
-                              Expanded(
-                                child: ElevatedButton(
-                                  style: ElevatedButton.styleFrom(
-                                    backgroundColor: AppColors.buttonBrown2,
-                                    foregroundColor: AppColors.textBlack,
-                                    minimumSize: const Size(0, 48),
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(8),
-                                    ),
-                                  ),
-                                  onPressed: _loading
-                                      ? null
-                                      : () {
-                                    Navigator.pop(context);
-                                  },
-                                  child: const Text(
-                                    'Cancelar',
-                                    style: TextStyle(fontWeight: FontWeight.bold),
-                                  ),
+                          ),
+                          const SizedBox(width: 14),
+                          Expanded(
+                            child: ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: AppColors.buttonGreen2,
+                                foregroundColor: AppColors.textBlack,
+                                minimumSize: const Size(0, 50),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(12),
                                 ),
+                                elevation: 2,
                               ),
-                              const SizedBox(width: 8),
-                              Expanded(
-                                child: ElevatedButton(
-                                  style: ElevatedButton.styleFrom(
-                                    backgroundColor: AppColors.buttonGreen2,
-                                    foregroundColor: AppColors.textBlack,
-                                    minimumSize: const Size(0, 48),
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(8),
+                              onPressed: _loading ? null : _onGuardar,
+                              child: _loading
+                                  ? const SizedBox(
+                                      width: 24,
+                                      height: 24,
+                                      child: CircularProgressIndicator(strokeWidth: 2),
+                                    )
+                                  : const Text(
+                                      'Guardar cambios',
+                                      style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
                                     ),
-                                  ),
-                                  onPressed: _loading ? null : _onGuardar,
-                                  child: const Text(
-                                    'Guardar cambios',
-                                    style: TextStyle(fontWeight: FontWeight.bold),
-                                  ),
-                                ),
-                              ),
-                            ],
+                            ),
                           ),
                         ],
                       ),
-                    ),
+                    ],
                   ),
                 ),
               ),

--- a/lib/views/user/editar_perfil.dart
+++ b/lib/views/user/editar_perfil.dart
@@ -1,8 +1,110 @@
 import 'package:biodetect/themes.dart';
 import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:biodetect/views/session/inicio_sesion.dart';
+import 'package:biodetect/views/user/cambiar_contrasena.dart';
 
-class EditarPerfil extends StatelessWidget {
+class EditarPerfil extends StatefulWidget {
   const EditarPerfil({super.key});
+
+  @override
+  State<EditarPerfil> createState() => _EditarPerfilState();
+}
+
+class _EditarPerfilState extends State<EditarPerfil> {
+  final _formKey = GlobalKey<FormState>();
+  final _nombreController = TextEditingController();
+  final _correoController = TextEditingController();
+  bool _loading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _cargarDatosUsuario();
+  }
+
+  Future<void> _cargarDatosUsuario() async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    final doc = await FirebaseFirestore.instance.collection('users').doc(user.uid).get();
+    final data = doc.data();
+    if (data != null) {
+      _nombreController.text = data['fullname'] ?? '';
+      _correoController.text = data['email'] ?? '';
+    }
+    setState(() {});
+  }
+
+  Future<void> _guardarCambios() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _loading = true);
+
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+
+    final nuevoNombre = _nombreController.text.trim();
+    final nuevoCorreo = _correoController.text.trim();
+
+    try {
+      // Si el correo cambió, inicia el flujo de verificación
+      if (nuevoCorreo != user.email) {
+        await user.verifyBeforeUpdateEmail(nuevoCorreo);
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text(
+                'Te hemos enviado un enlace de verificación a tu nuevo correo. '
+                'Por favor, verifica tu correo y vuelve a iniciar sesión para completar el cambio.',
+              ),
+            ),
+          );
+          // Espera un poco para que el usuario vea el mensaje
+          await Future.delayed(const Duration(seconds: 2));
+          // Redirige al login y elimina el historial de navegación
+          Navigator.of(context).pushAndRemoveUntil(
+            MaterialPageRoute(builder: (context) => const InicioSesion()),
+            (route) => false,
+          );
+        }
+        await FirebaseAuth.instance.signOut();
+        return;
+      }
+
+      // Si solo cambió el nombre
+      await FirebaseFirestore.instance.collection('users').doc(user.uid).update({
+        'fullname': nuevoNombre,
+      });
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Perfil actualizado correctamente')),
+        );
+        Navigator.pop(context, true);
+      }
+    } on FirebaseAuthException catch (e) {
+      String msg = 'Error al actualizar: ${e.message}';
+      if (e.code == 'requires-recent-login') {
+        msg = 'Por seguridad, vuelve a iniciar sesión para cambiar el correo.';
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(msg)),
+      );
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error inesperado: $e')),
+      );
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
+  void dispose() {
+    _nombreController.dispose();
+    _correoController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -43,126 +145,149 @@ class EditarPerfil extends StatelessWidget {
               ),
               Padding(
                 padding: const EdgeInsets.all(16),
-                child: Column(
-                  children: [
-                    // Foto de perfil editable
-                    Center(
-                      child: Stack(
-                        children: [
-                          Card(
-                            shape: const CircleBorder(),
-                            color: Colors.transparent,
-                            elevation: 4,
-                            child: CircleAvatar(
-                              radius: 60,
-                              backgroundColor: AppColors.forestGreen,
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    children: [
+                      // Foto de perfil editable (icono por defecto)
+                      Center(
+                        child: Stack(
+                          children: [
+                            Card(
+                              shape: const CircleBorder(),
+                              color: Colors.transparent,
+                              elevation: 4,
                               child: CircleAvatar(
-                                radius: 57,
-                                backgroundImage: const AssetImage('assets/ic_default_profile.png'),
-                                backgroundColor: AppColors.white,
+                                radius: 60,
+                                backgroundColor: AppColors.forestGreen,
+                                child: const Icon(
+                                  Icons.person,
+                                  size: 60,
+                                  color: AppColors.slateGrey,
+                                ),
                               ),
                             ),
+                            Positioned(
+                              bottom: 0,
+                              right: 0,
+                              child: FloatingActionButton(
+                                mini: true,
+                                backgroundColor: AppColors.buttonGreen3,
+                                onPressed: () {
+                                  // Acción para editar foto (opcional)
+                                },
+                                child: const Icon(Icons.edit, color: AppColors.textWhite),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                      // Campo: Nombre completo
+                      TextFormField(
+                        controller: _nombreController,
+                        decoration: InputDecoration(
+                          labelText: 'Nombre completo',
+                          labelStyle: const TextStyle(color: AppColors.textWhite),
+                          filled: true,
+                          fillColor: AppColors.slateGreen,
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(8),
                           ),
-                          Positioned(
-                            bottom: 0,
-                            right: 0,
-                            child: FloatingActionButton(
-                              mini: true,
-                              backgroundColor: AppColors.buttonGreen3,
+                        ),
+                        style: const TextStyle(color: AppColors.textWhite),
+                        validator: (value) =>
+                            value == null || value.trim().isEmpty ? 'Ingresa tu nombre' : null,
+                      ),
+                      const SizedBox(height: 16),
+                      // Campo: Correo electrónico
+                      TextFormField(
+                        controller: _correoController,
+                        decoration: InputDecoration(
+                          labelText: 'Correo electrónico',
+                          labelStyle: const TextStyle(color: AppColors.textWhite),
+                          filled: true,
+                          fillColor: AppColors.slateGreen,
+                          border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                        style: const TextStyle(color: AppColors.textWhite),
+                        keyboardType: TextInputType.emailAddress,
+                        validator: (value) {
+                          if (value == null || value.trim().isEmpty) {
+                            return 'Ingresa tu correo';
+                          }
+                          if (!RegExp(r'^[^@]+@[^@]+\.[^@]+').hasMatch(value)) {
+                            return 'Correo no válido';
+                          }
+                          return null;
+                        },
+                      ),
+                      const SizedBox(height: 24),
+                      // Botones de acción
+                      Row(
+                        children: [
+                          Expanded(
+                            child: ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: AppColors.buttonBrown2,
+                                foregroundColor: AppColors.textBlack,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                minimumSize: const Size(0, 48),
+                              ),
                               onPressed: () {
-                                // Acción para editar foto
+                                Navigator.pop(context);
                               },
-                              child: const Icon(Icons.edit, color: AppColors.textWhite),
+                              child: const Text('Cancelar', style: TextStyle(fontWeight: FontWeight.bold)),
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: AppColors.buttonGreen2,
+                                foregroundColor: AppColors.textBlack,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                minimumSize: const Size(0, 48),
+                              ),
+                              onPressed: _loading ? null : _guardarCambios,
+                              child: _loading
+                                  ? const SizedBox(
+                                      width: 24,
+                                      height: 24,
+                                      child: CircularProgressIndicator(strokeWidth: 2),
+                                    )
+                                  : const Text('Guardar cambios', style: TextStyle(fontWeight: FontWeight.bold)),
                             ),
                           ),
                         ],
                       ),
-                    ),
-                    const SizedBox(height: 24),
-                    // Campo: Nombre completo
-                    TextFormField(
-                      decoration: InputDecoration(
-                        labelText: 'Nombre completo',
-                        labelStyle: const TextStyle(color: AppColors.textWhite),
-                        filled: true,
-                        fillColor: AppColors.slateGreen,
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                      ),
-                      style: const TextStyle(color: AppColors.textWhite),
-                    ),
-                    const SizedBox(height: 16),
-                    // Campo: Correo electrónico
-                    TextFormField(
-                      decoration: InputDecoration(
-                        labelText: 'Correo electrónico',
-                        labelStyle: const TextStyle(color: AppColors.textWhite),
-                        filled: true,
-                        fillColor: AppColors.slateGreen,
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                      ),
-                      style: const TextStyle(color: AppColors.textWhite),
-                      keyboardType: TextInputType.emailAddress,
-                    ),
-                    const SizedBox(height: 24),
-                    // Botones de acción
-                    Row(
-                      children: [
-                        Expanded(
-                          child: ElevatedButton(
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: AppColors.buttonBrown2,
-                              foregroundColor: AppColors.textBlack,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                              minimumSize: const Size(0, 48),
+                      const SizedBox(height: 36),
+                      // Enlace para cambiar contraseña
+                      Center(
+                        child: TextButton(
+                          onPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(builder: (_) => const CambiarContrasenaScreen()),
+                            );
+                          },
+                          child: const Text(
+                            'Cambiar contraseña',
+                            style: TextStyle(
+                              color: AppColors.textWhite,
+                              fontWeight: FontWeight.bold,
                             ),
-                            onPressed: () {
-                              Navigator.pop(context);
-                            },
-                            child: const Text('Cancelar', style: TextStyle(fontWeight: FontWeight.bold)),
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: ElevatedButton(
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: AppColors.buttonGreen2,
-                              foregroundColor: AppColors.textBlack,
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(8),
-                              ),
-                              minimumSize: const Size(0, 48),
-                            ),
-                            onPressed: () {
-                              // Acción para guardar cambios
-                            },
-                            child: const Text('Guardar cambios', style: TextStyle(fontWeight: FontWeight.bold)),
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 36),
-                    // Enlace para cambiar contraseña
-                    Center(
-                      child: TextButton(
-                        onPressed: () {
-                          // Acción para cambiar contraseña
-                        },
-                        child: const Text(
-                          'Cambiar contraseña',
-                          style: TextStyle(
-                            color: AppColors.textWhite,
-                            fontWeight: FontWeight.bold,
                           ),
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ],


### PR DESCRIPTION
- Carga datos reales del usuario, estadísticas y badges desde Firestore en el perfil.
- Muestra la foto de perfil (de Storage si existe, si no, un ícono por defecto).
- Muestra nombre, correo, verificación, estadísticas y badges.
- Permite editar nombre y correo (correo se actualiza en Auth y Firestore, nombre solo en Firestore).
- Los campos del formulario de edición se llenan automáticamente con los datos actuales del usuario.
- Si el correo cambia, se envía enlace de verificación y se cierra sesión.
- Si Firebase pide re-autenticación, muestra un mensaje claro.
- Permite cambiar la contraseña desde la pantalla de editar perfil.
- Mejora visual en inputs y botones de cambiar contraseña, con textos más oscuros y sin Card para mayor espacio.
- Acciones rápidas: Mis Bitácoras, Editar Perfil, Cerrar Sesión."